### PR TITLE
kernel: usb: simplify r8152 dependencies

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -1439,11 +1439,11 @@ $(eval $(call KernelPackage,usb-net-rtl8150))
 
 define KernelPackage/usb-net-rtl8152
   TITLE:=Kernel module for USB-to-Ethernet Realtek convertors
-  DEPENDS:=+r8152-firmware +kmod-crypto-sha256 +kmod-usb-net-cdc-ncm
+  DEPENDS:=+r8152-firmware +kmod-crypto-sha256 +kmod-mii
   KCONFIG:=CONFIG_USB_RTL8152
   FILES:=$(LINUX_DIR)/drivers/$(USBNET_DIR)/r8152.ko
   AUTOLOAD:=$(call AutoProbe,r8152)
-  $(call AddDepends/usb-net, +LINUX_5_10:kmod-crypto-hash)
+  $(call AddDepends/usb, +LINUX_5_10:kmod-crypto-hash)
 endef
 
 define KernelPackage/usb-net-rtl8152/description


### PR DESCRIPTION
It doesn't depend on either usb-net or usb-net-cdc-ncm. It does, however, depend on mii. Fix thusly, and make it depend explicitly on usb, not usb-net.

While at it, add a conditional dependency on libphy, for future kernel versions.

# Pull Request 规则，创建时请删除

- 禁止有关 "GitHub Actions" 的提交
- 禁止使用 users.noreply.github.com 提交
